### PR TITLE
In `mysql_backend__write` reset correct prepared statement

### DIFF
--- a/mysql/mysql.c
+++ b/mysql/mysql.c
@@ -289,7 +289,7 @@ int mysql_backend__write(git_oid *oid, git_odb_backend *_backend, const void *da
     return GIT_ERROR;
 
   // reset the statement for further use
-  if (mysql_stmt_reset(backend->st_read_header) != 0)
+  if (mysql_stmt_reset(backend->st_write) != 0)
     return GIT_ERROR;
 
   return GIT_SUCCESS;


### PR DESCRIPTION
`mysql_backend__write` was resetting the prepared statement for `st_read_header` instead of `st_write`.